### PR TITLE
Fixed security issue - unnecessary port routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,6 @@ services:
     container_name: influxdb
     volumes:
       - "./data/influxdb/:/var/lib/influxdb"
-    ports:
-      - "8083:8083"
-      - "8086:8086"
     env_file:
       - ./env/db.env
   web:


### PR DESCRIPTION
It's not essential routing ports of Influxdb in docker composer. They cause security issues and make the database accessible from outside the server on all the server's IPs.