### PR TITLE
speedtest-cli 403 error without secure flag

### DIFF
--- a/speedtest/scripts/init_test_connection.sh
+++ b/speedtest/scripts/init_test_connection.sh
@@ -5,7 +5,7 @@ while true
 do 
     TIMESTAMP=$(date '+%s')
 
-	COMMAND=/app/speedtest/speedtest-cli
+	COMMAND="/app/speedtest/speedtest-cli --secure"
 	if [ -n "${TEST_SERVER}" ]; then
 		COMMAND="${COMMAND} --server ${TEST_SERVER}"
 	fi


### PR DESCRIPTION
Noticed my home script stopped reporting Download/Upload, adding a secure flag fixed it.

Its weird because users on home assistant reported this back on [Aug 15th](https://github.com/home-assistant/core/issues/76842), but my dashboard has been reporting fine until Nov 19th. My guess is not every speedtest server was configured to block http, but they are slowly blocking it.